### PR TITLE
Fix bug - position of comment

### DIFF
--- a/Training.py
+++ b/Training.py
@@ -20,7 +20,8 @@ from tensorflow.contrib.signal.python.ops import window_ops
 ex = Experiment('Waveunet Training', ingredients=[config_ingredient])
 
 @ex.config
-def set_seed(): # Executed for training, sets the seed value to the Sacred config so that Sacred fixes the Python and Numpy RNG to the same state everytime.
+# Executed for training, sets the seed value to the Sacred config so that Sacred fixes the Python and Numpy RNG to the same state everytime.
+def set_seed():
     seed = 1337
 
 @config_ingredient.capture


### PR DESCRIPTION
Related https://github.com/f90/Wave-U-Net/issues/21.

`def` and comment should be in different lines.
`sacred` reads comment on the same line of `def`.