### PR TITLE
Faster resampling

### DIFF
--- a/Utils.py
+++ b/Utils.py
@@ -108,14 +108,10 @@ def AudioClip(x, training):
 
 def load(path, sr=22050, mono=True, offset=0.0, duration=None, dtype=np.float32):
     # ALWAYS output (n_frames, n_channels) audio
-    y, orig_sr = librosa.load(path, None, mono, offset, duration, dtype)
+    y, orig_sr = librosa.load(path, sr, mono, offset, duration, dtype)
     if len(y.shape) == 1:
         y = np.expand_dims(y, axis=0)
-    y = y.T
-    if sr != None:
-        return resample(y, orig_sr, sr), sr
-    else:
-        return y, orig_sr
+    return y.T, orig_sr
 
 def crop(tensor, target_shape, match_feature_dim=True):
     '''


### PR DESCRIPTION
Preprocessing during training with the latest code in master is extremely slow (several minutes per song, sometimes >10 minutes). Profiling showed that almost all of the time is spent in `scipy.signal.resample`, which uses the FFT and is therefore very slow for a large/prime number of samples. I suggest to let librosa do the resampling using `resampy`'s fast algorithm.

The new code improves resampling time on one song I tested it from CCMixter from 15 minutes to 36 seconds on my machine.

Evaluate.py still calls the slow resample, this probably should be fixed too by either reverting `Utils.resample` to use `scipy.signal.resampe_poly` or using `librosa.core.resample` instead.