### PR TITLE
Fix validation/test loss to be mean of source losses.

### DIFF
--- a/Test.py
+++ b/Test.py
@@ -68,7 +68,7 @@ def test(model_config, partition, model_folder, load_model):
             separator_loss += tf.reduce_mean(tf.abs(real_mag - sep_source))
         else:
             separator_loss += tf.reduce_mean(tf.square(real_source - sep_source))
-        separator_loss = separator_loss / float(model_config["num_sources"])  # Normalise by number of sources
+    separator_loss = separator_loss / float(model_config["num_sources"])  # Normalise by number of sources
 
     while True:
         try:


### PR DESCRIPTION
One tab character too much. :)

The `test` function was reporting a loss that was too low. The loss put a different weight on each source, relative to the order of `model_config['source_names']`.

For example, in the case of two sources (voice and accompaniment), the loss should be `(voice_loss + accomp_loss) / 2` but instead it was `voice_loss / 4 + accomp_loss / 2`.

(The training loss was and remains correct.)